### PR TITLE
Continuing the work you've done so far

### DIFF
--- a/android/examples/invocationhandler/main.zig
+++ b/android/examples/invocationhandler/main.zig
@@ -64,7 +64,7 @@ pub const AndroidApp = struct {
     pipe: [2]std.os.fd_t = undefined,
     // This is used with futexes so that runOnUiThread waits until the callback is completed
     // before returning.
-    uiThreadCondition: std.atomic.Atomic(u32) = std.atomic.Atomic(u32).init(0),
+    uiThreadCondition: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
     uiThreadLooper: *android.ALooper = undefined,
     uiThreadId: std.Thread.Id = undefined,
 

--- a/android/examples/textview/main.zig
+++ b/android/examples/textview/main.zig
@@ -32,7 +32,7 @@ pub const AndroidApp = struct {
     pipe: [2]std.os.fd_t = undefined,
     // This is used with futexes so that runOnUiThread waits until the callback is completed
     // before returning.
-    uiThreadCondition: std.atomic.Atomic(u32) = std.atomic.Atomic(u32).init(0),
+    uiThreadCondition: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
     uiThreadLooper: *android.ALooper = undefined,
     uiThreadId: std.Thread.Id = undefined,
 

--- a/build.zig
+++ b/build.zig
@@ -7,7 +7,7 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    var examplesDir = try std.fs.cwd().openDir("examples", .{});
+    var examplesDir = try std.fs.cwd().openDir("examples", .{ .iterate = true });
     defer examplesDir.close();
 
     const broken = switch (target.getOsTag()) {

--- a/src/async.zig
+++ b/src/async.zig
@@ -15,7 +15,7 @@ pub const ThreadPool = struct {
         thread: std.Thread,
         /// The last time a task was executed on this thread, in milliseconds.
         last_used: i64,
-        busy: std.atomic.Atomic(bool) = false,
+        busy: std.atomic.Value(bool) = false,
     };
 
     pub fn init(allocator: std.mem.Allocator) ThreadPool {

--- a/src/backends/android/backend.zig
+++ b/src/backends/android/backend.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const shared = @import("../shared.zig");
 const lib = @import("../../main.zig");
 const android = @import("android");
+const trait = @import("../../trait.zig");
 
 const EventFunctions = shared.EventFunctions(@This());
 const EventType = shared.BackendEventType;
@@ -154,7 +155,7 @@ pub fn Events(comptime T: type) type {
 
         pub inline fn setUserData(self: *T, data: anytype) void {
             comptime {
-                if (!std.meta.trait.isSingleItemPtr(@TypeOf(data))) {
+                if (!trait.isSingleItemPtr(@TypeOf(data))) {
                     @compileError(std.fmt.comptimePrint("Expected single item pointer, got {s}", .{@typeName(@TypeOf(data))}));
                 }
             }

--- a/src/backends/android/backend.zig
+++ b/src/backends/android/backend.zig
@@ -10,7 +10,7 @@ const MouseButton = shared.MouseButton;
 
 pub const PeerType = *anyopaque; // jobject but not optional
 
-var activeWindows = std.atomic.Atomic(usize).init(0);
+var activeWindows = std.atomic.Value(usize).init(0);
 var hasInit: bool = false;
 var theApp: *backendExport.AndroidApp = undefined;
 
@@ -732,7 +732,7 @@ pub const backendExport = struct {
         pipe: [2]std.os.fd_t = undefined,
         // This is used with futexes so that runOnUiThread waits until the callback is completed
         // before returning.
-        uiThreadCondition: std.atomic.Atomic(u32) = std.atomic.Atomic(u32).init(0),
+        uiThreadCondition: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
 
         // TODO: add an interface in capy for handling stored state
         pub fn init(allocator: std.mem.Allocator, activity: *android.ANativeActivity, stored_state: ?[]const u8) !AndroidApp {

--- a/src/backends/gles/backend.zig
+++ b/src/backends/gles/backend.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const shared = @import("../shared.zig");
 const lib = @import("../../main.zig");
+const trait = @import("../../trait.zig");
 const c = @cImport({
     @cDefine("GLFW_INCLUDE_ES3", {});
     @cInclude("GLFW/glfw3.h");
@@ -161,7 +162,7 @@ pub fn Events(comptime T: type) type {
 
         pub inline fn setUserData(self: *T, data: anytype) void {
             comptime {
-                if (!std.meta.trait.isSingleItemPtr(@TypeOf(data))) {
+                if (!trait.isSingleItemPtr(@TypeOf(data))) {
                     @compileError(std.fmt.comptimePrint("Expected single item pointer, got {s}", .{@typeName(@TypeOf(data))}));
                 }
             }

--- a/src/backends/gtk/backend.zig
+++ b/src/backends/gtk/backend.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const shared = @import("../shared.zig");
 const lib = @import("../../main.zig");
+const trait = @import("../../trait.zig");
 pub const c = @cImport({
     @cInclude("gtk/gtk.h");
 });
@@ -441,7 +442,7 @@ pub fn Events(comptime T: type) type {
 
         pub inline fn setUserData(self: *T, data: anytype) void {
             comptime {
-                if (!std.meta.trait.isSingleItemPtr(@TypeOf(data))) {
+                if (!trait.isSingleItemPtr(@TypeOf(data))) {
                     @compileError(std.fmt.comptimePrint("Expected single item pointer, got {s}", .{@typeName(@TypeOf(data))}));
                 }
             }

--- a/src/backends/gtk/backend.zig
+++ b/src/backends/gtk/backend.zig
@@ -20,7 +20,7 @@ const GTK_VERSION = std.SemanticVersion.Range{
 
 pub const Capabilities = .{ .useEventLoop = true };
 
-var activeWindows = std.atomic.Atomic(usize).init(0);
+var activeWindows = std.atomic.Value(usize).init(0);
 var randomWindow: *c.GtkWidget = undefined;
 
 var hasInit: bool = false;

--- a/src/backends/wasm/backend.zig
+++ b/src/backends/wasm/backend.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const shared = @import("../shared.zig");
 const lib = @import("../../main.zig");
 const js = @import("js.zig");
+const trait = @import("../../trait.zig");
+
 const lasting_allocator = lib.internal.lasting_allocator;
 
 const EventType = shared.BackendEventType;
@@ -106,7 +108,7 @@ pub fn Events(comptime T: type) type {
 
         pub inline fn setUserData(self: *T, data: anytype) void {
             comptime {
-                if (!std.meta.trait.isSingleItemPtr(@TypeOf(data))) {
+                if (!trait.isSingleItemPtr(@TypeOf(data))) {
                     @compileError(std.fmt.comptimePrint("Expected single item pointer, got {s}", .{@typeName(@TypeOf(data))}));
                 }
             }

--- a/src/backends/win32/backend.zig
+++ b/src/backends/win32/backend.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const lib = @import("../../main.zig");
 const shared = @import("../shared.zig");
+const trait = @import("../../trait.zig");
 const os = @import("builtin").target.os;
 const log = std.log.scoped(.win32);
 
@@ -583,7 +584,7 @@ pub fn Events(comptime T: type) type {
 
         pub inline fn setUserData(self: *T, data: anytype) void {
             comptime {
-                if (!std.meta.trait.isSingleItemPtr(@TypeOf(data))) {
+                if (!trait.isSingleItemPtr(@TypeOf(data))) {
                     @compileError(std.fmt.comptimePrint("Expected single item pointer, got {s}", .{@typeName(@TypeOf(data))}));
                 }
             }

--- a/src/components/Navigation.zig
+++ b/src/components/Navigation.zig
@@ -11,7 +11,7 @@ pub const Navigation = struct {
     peer: ?backend.Container = null,
     widget_data: Navigation.WidgetData = .{},
 
-    relayouting: std.atomic.Atomic(bool) = std.atomic.Atomic(bool).init(false),
+    relayouting: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     routeName: Atom([]const u8),
     activeChild: *Widget,
     routes: std.StringHashMap(Widget),

--- a/src/components/TextArea.zig
+++ b/src/components/TextArea.zig
@@ -12,7 +12,7 @@ pub const TextArea = struct {
     peer: ?backend.TextArea = null,
     widget_data: TextArea.WidgetData = .{},
     text: StringAtom = StringAtom.of(""),
-    _wrapperTextBlock: std.atomic.Atomic(bool) = std.atomic.Atomic(bool).init(false),
+    _wrapperTextBlock: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     // TODO: replace with TextArea.setFont(.{ .family = "monospace" }) ?
     /// Whether to let the system choose a monospace font for us and use it in this TextArea..

--- a/src/components/TextField.zig
+++ b/src/components/TextField.zig
@@ -14,7 +14,7 @@ pub const TextField = struct {
     widget_data: TextField.WidgetData = .{},
     text: StringAtom = StringAtom.of(""),
     readOnly: Atom(bool) = Atom(bool).of(false),
-    _wrapperTextBlock: std.atomic.Atomic(bool) = std.atomic.Atomic(bool).init(false),
+    _wrapperTextBlock: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     pub fn init(config: TextField.Config) TextField {
         var field = TextField.init_events(TextField{

--- a/src/data.zig
+++ b/src/data.zig
@@ -39,7 +39,7 @@ pub fn lerp(a: anytype, b: @TypeOf(a), t: f64) @TypeOf(a) {
         }
     } else if (comptime trait.isContainer(T) and @hasDecl(T, "lerp")) {
         return T.lerp(a, b, t);
-    } else if (comptime std.meta.trait.is(.Optional)(T)) {
+    } else if (comptime trait.is(.Optional)(T)) {
         if (a != null and b != null) {
             return lerp(a.?, b.?, t);
         } else {

--- a/src/dev_tools.zig
+++ b/src/dev_tools.zig
@@ -1,6 +1,7 @@
 //! Capy Development Tools Server
 const std = @import("std");
 const internal = @import("internal.zig");
+const trait = @import("trait.zig");
 
 const DEV_TOOLS_PORT = 42671;
 const log = std.log.scoped(.dev_tools);
@@ -73,7 +74,7 @@ pub fn init() !void {
 }
 
 fn readStructField(comptime T: type, reader: anytype) !T {
-    if (comptime std.meta.trait.isIntegral(T)) {
+    if (comptime trait.isIntegral(T)) {
         return try reader.readIntBig(T);
     } else if (T == []const u8) {
         const length = try std.leb.readULEB128(u32, reader);
@@ -84,7 +85,7 @@ fn readStructField(comptime T: type, reader: anytype) !T {
 }
 
 fn writeStructField(comptime T: type, writer: anytype, value: T) !void {
-    if (comptime std.meta.trait.isIntegral(T)) {
+    if (comptime trait.isIntegral(T)) {
         try writer.writeIntBig(T, value);
     } else if (T == []const u8) {
         try std.leb.writeULEB128(writer, value.len);

--- a/src/fuzz.zig
+++ b/src/fuzz.zig
@@ -1,5 +1,6 @@
 //! Randomly test data and lower it down
 const std = @import("std");
+const trait = @import("trait.zig");
 
 pub fn forAll(comptime T: type) Iterator(T) {
     return Iterator(T).init();
@@ -115,7 +116,7 @@ pub fn testFunction(comptime T: type, duration: i64, func: fn (T) anyerror!void)
 
         pub fn hypothetize(self: *Self, callback: fn (T) anyerror!void) !Hypothesis {
             var elements = std.ArrayList(Hypothesis.HypothesisElement).init(std.testing.allocator);
-            if (comptime std.meta.trait.isNumber(T)) {
+            if (comptime trait.isNumber(T)) {
                 std.sort.sort(T, self.items, {}, comptime std.sort.asc(T));
                 const smallest = self.items[0];
                 const biggest = self.items[self.items.len - 1];

--- a/src/internal.zig
+++ b/src/internal.zig
@@ -340,7 +340,7 @@ fn iterateApplyFields(comptime T: type, target: anytype, config: GenerateConfigS
             @field(target, field.name).set(
                 @field(config, name),
             );
-        } else if (comptime std.meta.trait.is(.Struct)(FieldType)) {
+        } else if (comptime trait.is(.Struct)(FieldType)) {
             iterateApplyFields(T, &@field(target, field.name), config);
         }
     }


### PR DESCRIPTION
Hey Dave, I also am interested in getting capy working on zig master. 

First thing I did was add `iterate = true` to the `build.zig` openDir change due to later in the build file needing iterator access and the 0.11.0 code beforehand had that.

Then I just started manually digging into the errors of the atomic.Atomic stuff as well as leftover meta.trait stuff laying around from your change.

There are 5 more meta.trait references left in the codebase as of now but they are using methods that you didn't build into your trait.zig yet so I left them be temporarily. `isZigString`, `hasUniqueRepresentation`, and `isPtrTo` are the ones remaining.  

Looking forward to getting this working as well :)

I'm on zig version 0.12.0-dev.1830+779b8e259 which is just a bit ahead of where you originally targeted and it's current master.