### PR TITLE
More fixes towards compatibility with both 0.11.0 and master

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -54,10 +54,11 @@ pub fn init() !void {
         try dev_tools.init();
     }
 
-    var listener = Listener.init(.{ .listened = eventStep, .callback = animateAtoms }) catch unreachable;
+    var listener = eventStep.listen(.{ .callback = animateAtoms }) catch unreachable;
+    // The listener is enabled only if there is at least 1 atom currently being animated
     listener.enabled.dependOn(.{&@import("data.zig")._animatedAtomsLength}, &struct {
         fn a(num: usize) bool {
-            return num > 0;
+            return num >= 1;
         }
     }.a) catch unreachable;
 }

--- a/src/timer.zig
+++ b/src/timer.zig
@@ -23,7 +23,6 @@ pub const Timer = struct {
     duration: Atom(u64) = Atom(u64).of(0),
     event_source: EventSource,
 
-    // TODO: timeout events
     pub fn init() !*Timer {
         const timer = try lasting_allocator.create(Timer);
         timer.* = .{


### PR DESCRIPTION
Thanks for adding in those extra trait methods! I went ahead and implemented them where they were needed. 

I had a couple more var->const updates for mutability error.

I believe I misunderstood some of the work I did with atomic changes and after trying to get it to work on both versions of zig I figured out where my misunderstanding was and made corrections. I also capitalized `AtomicValue` as that seemed more idiomatic of zig, happy to change it back if desired. 

One change I did change from your code that you may want to verify is I swapped `self.bindLock.cmpxchg` back to `self.bindLock.compareAndSwap` as it was in upstream master. cmpxchg broke my 0.11.0 on linux with a method not found error. I left cmpxchgStrong for master and that seemed to work for me.

I'm not completely compiling on master yet, but these are all the right direction I believe, and I'll leave more comments back on the upstream PR.